### PR TITLE
Add Web-clip Only Mode for Original Web Content

### DIFF
--- a/cmd/unenex/main.go
+++ b/cmd/unenex/main.go
@@ -20,6 +20,7 @@ var (
 	optionStyleFile   = flag.String("sf", "", "Specify a stylesheet file `path`")
 	optionStyleInline = flag.String("st", "", "Specify `stylesheet` text directly as a string.")
 	optionRootDir     = flag.String("d", ".", "Output `directory`")
+	optionWebClipOnly = flag.Bool("web-clip-only", false, "Only output web-clip content without Evernote styling")
 )
 
 func expandWildcard(args []string) []string {
@@ -73,7 +74,7 @@ func mains(args []string) error {
 				return err
 			}
 		} else {
-			if err := enex.ToHtmls(*optionRootDir, "", source, "", verbose, os.Stderr); err != nil {
+			if err := enex.ToHtmls(*optionRootDir, "", source, "", *optionWebClipOnly, verbose, os.Stderr); err != nil {
 				return err
 			}
 		}
@@ -84,7 +85,7 @@ func mains(args []string) error {
 	if *optionMarkdown {
 		return enex.FilesToMarkdowns(*optionRootDir, goDown, _args, verbose, os.Stderr)
 	}
-	return enex.FilesToHtmls(*optionRootDir, styleSheet, _args, verbose, os.Stderr)
+	return enex.FilesToHtmls(*optionRootDir, styleSheet, _args, *optionWebClipOnly, verbose, os.Stderr)
 }
 
 var version string

--- a/parser.go
+++ b/parser.go
@@ -41,6 +41,7 @@ type xmlNote struct {
 type xmlEnNote struct {
 	XMLName xml.Name `xml:"en-note"`
 	Text    string   `xml:",innerxml"`
+	WebClip bool     `xml:"web-clip,attr"`
 }
 
 // Resource represents information about an attachment.

--- a/unenex-html.go
+++ b/unenex-html.go
@@ -18,7 +18,8 @@ const indexHtmlFooter = "</body></html>"
 // The output HTML is saved under the directory specified by rootDir, with enexName as the note name.
 // The content is read from source, the styleSheet is applied to the HTML,
 // and debug and log information is written to wDebug and wLog, respectively.
-func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, wDebug, wLog io.Writer) error {
+// If webClipOnly is true, only the web-clip content will be output without Evernote styling.
+func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, webClipOnly bool, wDebug, wLog io.Writer) error {
 	exports, err := Parse(source, wDebug)
 	if err != nil {
 		return err
@@ -44,7 +45,10 @@ func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, wDebug,
 		index.Close()
 	}()
 
-	opt := &Option{ExHeader: styleSheet}
+	opt := &Option{
+		ExHeader:    styleSheet,
+		WebClipOnly: webClipOnly,
+	}
 
 	for _, note := range exports {
 		html, bundle := note.Extract(opt)
@@ -70,7 +74,8 @@ func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, wDebug,
 // FilesToHtmls converts multiple ENEX files into HTML format.
 // The output HTML files are saved under the directory specified by rootDir, with each ENEX file being processed.
 // The styleSheet is applied to the HTML, and debug and log information are written to wDebug and wLog, respectively.
-func FilesToHtmls(rootDir, styleSheet string, enexFiles []string, wDebug, wLog io.Writer) error {
+// If webClipOnly is true, only the web-clip content will be output without Evernote styling.
+func FilesToHtmls(rootDir, styleSheet string, enexFiles []string, webClipOnly bool, wDebug, wLog io.Writer) error {
 	wIndex, err := os.Create(filepath.Join(rootDir, "index.html"))
 	if err != nil {
 		return err
@@ -89,7 +94,7 @@ func FilesToHtmls(rootDir, styleSheet string, enexFiles []string, wDebug, wLog i
 			return err
 		}
 		enexName := getEnexBaseName(enexFileName)
-		if err := ToHtmls(rootDir, enexName, data, styleSheet, wDebug, wLog); err != nil {
+		if err := ToHtmls(rootDir, enexName, data, styleSheet, webClipOnly, wDebug, wLog); err != nil {
 			return err
 		}
 		fmt.Fprintf(wIndex, "<li><a href=\"%s/index.html\">%s</a></li>\n",


### PR DESCRIPTION
This PR adds a `--web-clip-only` command-line option that extracts only the essential web content from Evernote web-clip notes. When this option is used, the tool removes Evernote-specific styling and non-web-clip elements, resulting in cleaner HTML that closely resembles the original web page.

```bash
# Extract clean web content without Evernote styling
unenex --web-clip-only my-webclip.enex
```

This enhancement is particularly useful for users who want to preserve the original web content structure when converting Evernote exports, rather than the Evernote-styled version.